### PR TITLE
Fixed color code for color 15 bright white.

### DIFF
--- a/nord.conf
+++ b/nord.conf
@@ -40,4 +40,4 @@ color14  #8FBCBB
 
 # white
 color7   #E5E9F0
-color15  #B48EAD
+color15  #ECEFF4


### PR DESCRIPTION
The previous color for bright whit was B48EAD which is actually magenta.